### PR TITLE
feat(auto-merge): allowing to specify the merge method for auto-merge action

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ To configure the workflow, you can set any of these inputs to `true`:
 - If you set any `merge` parameter to `true`, the resulting pull request will be auto-merged, if all checks have passed
 - If you set any `approve` parameter to `true`, the pull request will be automatically approved (with a pull request review), if all checks have passed
 
-If you don't want to check for status checks, you can set the input `ignore-status-checks` to `true`. You can also set the `merge-commit` input if you want a custom merge commit message.
+If you don't want to check for status checks, you can set the input `ignore-status-checks` to `true`. 
+
+You can also set the `merge-commit` input if you want a custom merge commit message.
+
+You can also set the `merge-method` if your repo has branch protection rules that require a specific merge method. (default is `squash`.)
 
 ## 📄 License
 

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,8 @@ inputs:
     required: false
   merge-commit:
     required: false
+  merge-method:
+    required: false
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -35,6 +35,7 @@ export const tryAutoMergePR = async (
       owner,
       repo,
       pull_number: prNumber,
+      merge_method: getInput("merge-method") || "squash",
       commit_title: (
         getInput("merge-commit") || `:twisted_rightwards_arrows: Merge #$PR_NUMBER ($PR_TITLE)`
       )


### PR DESCRIPTION
This PR adds the ability to specify the [merge-method](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#merge-a-pull-request) to be used when auto-merging a PR. 