### PR TITLE
feat(auto-merge): apply custom labels on conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ You can also set the `merge-commit` input if you want a custom merge commit mess
 
 You can also set the `merge-method` if your repo has branch protection rules that require a specific merge method. (default is `squash`.)
 
+When `approve` parameters is set to `true`, when attempting to merge, if the pull request has a status that is not merge-able, you can set `labels-conflicted` parameter to apply custom labels to call for attentions.
+
 ## 📄 License
 
 - Code: [MIT](./LICENSE) © [Koj](https://koj.co)

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,8 @@ inputs:
   token:
     required: true
     description: "GitHub token"
+  labels-conflicted:
+    required: false
   labels-major:
     required: false
   auto-label:


### PR DESCRIPTION
This PR allows for custom labels to be applied to PR when attempting auto-merge but the status of pull-request is not merge-able.